### PR TITLE
Using certifcate signed by authority instead of self-signed certificate

### DIFF
--- a/common/visualization/xpra/playbooks/create.yaml
+++ b/common/visualization/xpra/playbooks/create.yaml
@@ -74,16 +74,3 @@
         state: present
         update_cache: yes
       when: ansible_os_family == 'Debian'
-    - name: Generate a random password
-      shell: openssl rand -hex 10 | tr -d '\n' > /tmp/randpassxpra.txt
-    - name: Get file content
-      slurp:
-        src: /tmp/randpassxpra.txt
-      register: pass_slurp
-    - name: Decode file content and expose it as operation output
-      set_fact:
-        RAND_PASS: "{{ pass_slurp['content'] | b64decode }}"
-    - name: cleanup
-      file:
-        path: /tmp/randpassxpra.txt
-        state: absent

--- a/common/visualization/xpra/playbooks/start.yaml
+++ b/common/visualization/xpra/playbooks/start.yaml
@@ -2,10 +2,93 @@
   hosts: all
   strategy: free
   tasks:
-    - name: Create password file
+    - name: "Copy certificate authority"
       copy:
-        content: "{{ RAND_PASS }}"
-        dest: "{{ansible_env.HOME}}/.password.txt"
+        content: "{{ CA_PEM }}"
+        dest: "{{ ansible_env.HOME }}/.xpra-ca.pem"
+        owner: "{{ ansible_env.USER }}"
+        group: "{{ ansible_env.USER }}"
+        mode: 0400
+      when: CA_PEM != ""
+
+    - name: "Copy certificate authority private key"
+      copy:
+        content: "{{ CA_KEY }}"
+        dest: "{{ ansible_env.HOME }}/.xpra-ca.key"
+        owner: "{{ ansible_env.USER }}"
+        group: "{{ ansible_env.USER }}"
+        mode: 0400
+      when: CA_PEM != ""
+
+    - name: Create certificate authority key
+      openssl_privatekey:
+        path: "{{ ansible_env.HOME }}/.xpra-ca.key"
+      when: CA_PEM == ""
+    - name: create the certificate authority CSR
+      openssl_csr:
+        path: "{{ ansible_env.HOME }}/.xpra-ca.csr"
+        privatekey_path: "{{ ansible_env.HOME }}/.xpra-ca.key"
+        common_name: "LEXISxpra"
+      when: CA_PEM == ""
+    - name: sign the CA CSR
+      openssl_certificate:
+        path: "{{ ansible_env.HOME }}/.xpra-ca.pem"
+        csr_path: "{{ ansible_env.HOME }}/.xpra-ca.csr"
+        privatekey_path: "{{ ansible_env.HOME }}/.xpra-ca.key"
+        provider: selfsigned
+      when: CA_PEM == ""
+    - name: create host CSR signing key
+      openssl_privatekey:
+        path: "{{ ansible_env.HOME }}/.xpra-host-key.pem"
+    - name: Get Host private IP address which TLS connections are accepted
+      set_fact:
+        subjectAltName: "IP:{{ IP_ADDRESS }},IP:127.0.0.1,DNS:localhost"
+    - name: Add Host public IP address to subjectAltName
+      set_fact:
+        subjectAltName: "IP:{{ PUBLIC_ADDRESS }},{{ subjectAltName }}"
+      when: PUBLIC_ADDRESS is defined and PUBLIC_ADDRESS != ''
+    - name: create the CSR for the Xpra server
+      openssl_csr:
+        path: "{{ ansible_env.HOME }}/.xpra-host.csr"
+        privatekey_path: "{{ ansible_env.HOME }}/.xpra-host-key.pem"
+        common_name: "LEXISxpra"
+        subjectAltName: "{{ subjectAltName }}"
+        key_usage:
+          - digitalSignature
+          - keyAgreement
+          - nonRepudiation
+          - keyEncipherment
+        extended_key_usage:
+          - clientAuth
+          - serverAuth
+    - name: sign the CSR for the Xpra server with passphrase
+      openssl_certificate:
+        path: "{{ansible_env.HOME}}/.xpra-ssl-cert-xpra.pem"
+        csr_path: "{{ ansible_env.HOME }}/.xpra-host.csr"
+        provider: ownca
+        ownca_path: "{{ ansible_env.HOME }}/.xpra-ca.pem"
+        ownca_privatekey_path: "{{ ansible_env.HOME }}/.xpra-ca.key"
+        ownca_privatekey_passphrase: "{{ CA_PASS }}"
+      when: CA_PASS != ""
+    - name: sign the CSR for the Xpra server
+      openssl_certificate:
+        path: "{{ansible_env.HOME}}/.xpra-ssl-cert-xpra.pem"
+        csr_path: "{{ ansible_env.HOME }}/.xpra-host.csr"
+        provider: ownca
+        ownca_path: "{{ ansible_env.HOME }}/.xpra-ca.pem"
+        ownca_privatekey_path: "{{ ansible_env.HOME }}/.xpra-ca.key"
+      when: CA_PASS == ""
+
+    - name: Generate a random password
+      shell: openssl rand -hex 10 | tr -d '\n' > {{ansible_env.HOME}}/.xpra-password.txt
+    - name: Get file content
+      slurp:
+        src: "{{ansible_env.HOME}}/.xpra-password.txt"
+      register: pass_slurp
+    - name: Decode file content
+      set_fact:
+        RAND_PASS: "{{ pass_slurp['content'] | b64decode }}"
+
     - name: Get xpra certificate
       copy:
         src: /etc/xpra/ssl-cert.pem
@@ -15,7 +98,7 @@
       become: yes
       become_method: sudo
     - name: Start Xpra
-      command: "xpra start --bind-wss=0.0.0.0:{{ PORT }} --exit-with-children --start-child=\"paraview\" --html=on --pidfile=/tmp/xprapid --wss-auth=file:filename={{ansible_env.HOME}}/.password.txt --ssl-cert {{ansible_env.HOME}}/.ssl-cert-xpra.pem"
+      command: "xpra start --bind-wss=0.0.0.0:{{ PORT }} --exit-with-children --start-child=\"paraview\" --html=on --pidfile=/tmp/xprapid --wss-auth=file:filename={{ansible_env.HOME}}/.xpra-password.txt --ssl-cert {{ansible_env.HOME}}/.xpra-ssl-cert-xpra.pem --ssl-key {{ansible_env.HOME}}/.xpra-host-key.pem"
     - name: Expose endpoint as operation output
       set_fact:
         ENDPOINT: "/index.html?password={{ RAND_PASS }}"

--- a/common/visualization/xpra/playbooks/submit_xpra.yaml
+++ b/common/visualization/xpra/playbooks/submit_xpra.yaml
@@ -2,10 +2,93 @@
   hosts: all
   strategy: free
   tasks:
-    - name: Create password file
+    - name: "Copy certificate authority"
       copy:
-        content: "{{ RAND_PASS }}"
-        dest: "{{ansible_env.HOME}}/.password.txt"
+        content: "{{ CA_PEM }}"
+        dest: "{{ ansible_env.HOME }}/.xpra-ca.pem"
+        owner: "{{ ansible_env.USER }}"
+        group: "{{ ansible_env.USER }}"
+        mode: 0400
+      when: CA_PEM != ""
+
+    - name: "Copy certificate authority private key"
+      copy:
+        content: "{{ CA_KEY }}"
+        dest: "{{ ansible_env.HOME }}/.xpra-ca.key"
+        owner: "{{ ansible_env.USER }}"
+        group: "{{ ansible_env.USER }}"
+        mode: 0400
+      when: CA_PEM != ""
+
+    - name: Create certificate authority key
+      openssl_privatekey:
+        path: "{{ ansible_env.HOME }}/.xpra-ca.key"
+      when: CA_PEM == ""
+    - name: create the certificate authority CSR
+      openssl_csr:
+        path: "{{ ansible_env.HOME }}/.xpra-ca.csr"
+        privatekey_path: "{{ ansible_env.HOME }}/.xpra-ca.key"
+        common_name: "LEXISxpra"
+      when: CA_PEM == ""
+    - name: sign the CA CSR
+      openssl_certificate:
+        path: "{{ ansible_env.HOME }}/.xpra-ca.pem"
+        csr_path: "{{ ansible_env.HOME }}/.xpra-ca.csr"
+        privatekey_path: "{{ ansible_env.HOME }}/.xpra-ca.key"
+        provider: selfsigned
+      when: CA_PEM == ""
+    - name: create host CSR signing key
+      openssl_privatekey:
+        path: "{{ ansible_env.HOME }}/.xpra-host-key.pem"
+    - name: Get Host private IP address which TLS connections are accepted
+      set_fact:
+        subjectAltName: "IP:{{ IP_ADDRESS }},IP:127.0.0.1,DNS:localhost"
+    - name: Add Host public IP address to subjectAltName
+      set_fact:
+        subjectAltName: "IP:{{ PUBLIC_ADDRESS }},{{ subjectAltName }}"
+      when: PUBLIC_ADDRESS is defined and PUBLIC_ADDRESS != ''
+    - name: create the CSR for the Xpra server
+      openssl_csr:
+        path: "{{ ansible_env.HOME }}/.xpra-host.csr"
+        privatekey_path: "{{ ansible_env.HOME }}/.xpra-host-key.pem"
+        common_name: "LEXISxpra"
+        subjectAltName: "{{ subjectAltName }}"
+        key_usage:
+          - digitalSignature
+          - keyAgreement
+          - nonRepudiation
+          - keyEncipherment
+        extended_key_usage:
+          - clientAuth
+          - serverAuth
+    - name: sign the CSR for the Xpra server with passphrase
+      openssl_certificate:
+        path: "{{ansible_env.HOME}}/.xpra-ssl-cert-xpra.pem"
+        csr_path: "{{ ansible_env.HOME }}/.xpra-host.csr"
+        provider: ownca
+        ownca_path: "{{ ansible_env.HOME }}/.xpra-ca.pem"
+        ownca_privatekey_path: "{{ ansible_env.HOME }}/.xpra-ca.key"
+        ownca_privatekey_passphrase: "{{ CA_PASS }}"
+      when: CA_PASS != ""
+    - name: sign the CSR for the Xpra server
+      openssl_certificate:
+        path: "{{ansible_env.HOME}}/.xpra-ssl-cert-xpra.pem"
+        csr_path: "{{ ansible_env.HOME }}/.xpra-host.csr"
+        provider: ownca
+        ownca_path: "{{ ansible_env.HOME }}/.xpra-ca.pem"
+        ownca_privatekey_path: "{{ ansible_env.HOME }}/.xpra-ca.key"
+      when: CA_PASS == ""
+
+    - name: Generate a random password
+      shell: openssl rand -hex 10 | tr -d '\n' > {{ansible_env.HOME}}/.xpra-password.txt
+    - name: Get file content
+      slurp:
+        src: "{{ansible_env.HOME}}/.xpra-password.txt"
+      register: pass_slurp
+    - name: Decode file content
+      set_fact:
+        RAND_PASS: "{{ pass_slurp['content'] | b64decode }}"
+
     - name: Get xpra certificate
       copy:
         src: /etc/xpra/ssl-cert.pem
@@ -15,7 +98,7 @@
       become: yes
       become_method: sudo
     - name: Start Xpra
-      command: "xpra start --bind-wss=0.0.0.0:{{ PORT }} --exit-with-children --start-child=\"paraview\" --html=on --pidfile=/tmp/xprapid --wss-auth=file:filename={{ansible_env.HOME}}/.password.txt --ssl-cert {{ansible_env.HOME}}/.ssl-cert-xpra.pem"
+      command: "xpra start --bind-wss=0.0.0.0:{{ PORT }} --exit-with-children --start-child=\"paraview\" --html=on --pidfile=/tmp/xprapid --wss-auth=file:filename={{ansible_env.HOME}}/.xpra-password.txt --ssl-cert {{ansible_env.HOME}}/.xpra-ssl-cert-xpra.pem --ssl-key {{ansible_env.HOME}}/.xpra-host-key.pem"
     - name: Expose endpoint as operation output
       set_fact:
         ENDPOINT: "/index.html?password={{ RAND_PASS }}"

--- a/common/visualization/xpra/types.yaml
+++ b/common/visualization/xpra/types.yaml
@@ -21,8 +21,19 @@ node_types:
         type: integer
         description: Port to use
         required: true
+      ca_pem:
+        description: "PEM-encoded certificate authority content, will be generated if not provided"
+        type: string
+        required: false
+      ca_key:
+        description: "Certificate authority private key content, will be generated if not provided"
+        type: string
+        required: false
+      ca_passphrase:
+        description: "Certificate authority private key passphrase"
+        type: string
+        required: false
     attributes:
-      rand_pass: {get_operation_output: [SELF, Standard, create, RAND_PASS]}
       endpoint: {get_operation_output: [SELF, Standard, start, ENDPOINT]}
       url: { concat: ["https://", get_attribute: [HOST, public_ip_address], ":", get_property: [SELF, port], get_attribute: [SELF, endpoint] ] }
     interfaces:
@@ -32,7 +43,11 @@ node_types:
         start:
           inputs:
             PORT: { get_property: [SELF, port] }
-            RAND_PASS: { get_attribute: [SELF, rand_pass] }
+            CA_PEM: { get_property: [SELF, ca_pem] }
+            CA_KEY: { get_property: [SELF, ca_key] }
+            CA_PASS: { get_property: [SELF, ca_passphrase] }
+            IP_ADDRESS: { get_attribute: [HOST, ip_address] }
+            PUBLIC_ADDRESS: { get_attribute: [HOST, public_address] }
           implementation: playbooks/start.yaml
         stop:
           implementation: playbooks/stop.yaml
@@ -52,8 +67,19 @@ node_types:
         type: integer
         description: Duration in minutes of the job execution
         required: true
+      ca_pem:
+        description: "PEM-encoded certificate authority content, will be generated if not provided"
+        type: string
+        required: false
+      ca_key:
+        description: "Certificate authority private key content, will be generated if not provided"
+        type: string
+        required: false
+      ca_passphrase:
+        description: "Certificate authority private key passphrase"
+        type: string
+        required: false
     attributes:
-      rand_pass: {get_operation_output: [SELF, Standard, create, RAND_PASS]}
       submit_date_epoch: { get_operation_output: [SELF, tosca.interfaces.node.lifecycle.Runnable, submit, XPRA_SUBMIT_DATE_EPOCH] }
       endpoint: {get_operation_output: [SELF, tosca.interfaces.node.lifecycle.Runnable, submit, ENDPOINT]}
       url: { concat: ["https://", get_attribute: [HOST, public_ip_address], ":", get_property: [SELF, port], get_attribute: [SELF, endpoint] ] }
@@ -67,7 +93,11 @@ node_types:
         submit:
           inputs:
             PORT: { get_property: [SELF, port] }
-            RAND_PASS: { get_attribute: [SELF, rand_pass] }
+            CA_PEM: { get_property: [SELF, ca_pem] }
+            CA_KEY: { get_property: [SELF, ca_key] }
+            CA_PASS: { get_property: [SELF, ca_passphrase] }
+            IP_ADDRESS: { get_attribute: [HOST, ip_address] }
+            PUBLIC_ADDRESS: { get_attribute: [HOST, public_address] }
           implementation: playbooks/submit_xpra.yaml
         run:
           inputs:

--- a/computational-fluid-dynamics/applications/openfoam/README.md
+++ b/computational-fluid-dynamics/applications/openfoam/README.md
@@ -25,6 +25,10 @@ The template expects the following input properties (mandatory inputs in **bold*
 * computation_encrypt_result_dataset: Should the result dataset be encrypted (default: false)
 * computation_compress_result_dataset: Should the result dataset be compressed (default: false)
 * visualization_directory: Directory where visualization data will be accesible on a cloud instance (default: openfoam)
+* visualization_ca_pem: PEM-encoded certificate authority content. Will be generated if not provided,
+but the user will get a warning that he attempts to connect to a server with an invalid certificate authority (as unknown certificate issuer)
+* visualization_ca_key: Certificate authority private key content, will be generated if not provided
+* visualization_ca_passphrase: Certificate authority private key passphrase
 * visualization_port: Port to use to expose the remote display, should be > 1024 (default: 8765)
 
 ## Ouput properties

--- a/computational-fluid-dynamics/applications/openfoam/openfoam_template.yaml
+++ b/computational-fluid-dynamics/applications/openfoam/openfoam_template.yaml
@@ -69,6 +69,18 @@ topology_template:
       description: Directory where visualization data will be stored
       default: "openfoam"
       required: false
+    visualization_ca_pem:
+      description: "PEM-encoded certificate authority content, will be generated if not provided"
+      type: string
+      required: false
+    visualization_ca_key:
+      description: "Certificate authority private key content, will be generated if not provided"
+      type: string
+      required: false
+    visualization_ca_passphrase:
+      description: "Certificate authority private key passphrase"
+      type: string
+      required: false
     visualization_port:
       type: integer
       description: "Port to use to expose the remote display (should be > 1024)"
@@ -244,6 +256,9 @@ topology_template:
       properties:
         port: { get_input: visualization_port }
         walltime_minutes: { get_input: visualization_walltime_minutes }
+        ca_pem: { get_input: visualization_ca_pem }
+        ca_key: { get_input: visualization_ca_key }
+        ca_passphrase: { get_input: visualization_ca_passphrase }
       requirements:
         - hostedOnComputeHost:
             type_requirement: host

--- a/visualization/applications/xpra/README.md
+++ b/visualization/applications/xpra/README.md
@@ -21,7 +21,11 @@ The template expects the following input properties (mandatory inputs in **bold*
 * visualization_decrypt_input_dataset: Is the input dataset encrypted (default: false)
 * visualization_uncompress_input_dataset: Is the input dataset compressed (default: false)
 * visualization_directory: Directory where visualization data will be accesible on a cloud instance (default: visualization)
-* mount_point: Directory where visualization data will be mounted from Cloud staging area (default: /mnt/visualization)
+* visualization_mount_point: Directory where visualization data will be mounted from Cloud staging area (default: /mnt/visualization)
+* visualization_ca_pem: PEM-encoded certificate authority content. Will be generated if not provided,
+but the user will get a warning that he attempts to connect to a server with an invalid certificate authority (as unknown certificate issuer)
+* visualization_ca_key: Certificate authority private key content, will be generated if not provided
+* visualization_ca_passphrase: Certificate authority private key passphrase
 * visualization_port: Port to use to expose the remote display, should be > 1024 (default: 8765)
 
 ## Ouput properties

--- a/visualization/applications/xpra/visualization_template.yaml
+++ b/visualization/applications/xpra/visualization_template.yaml
@@ -50,10 +50,22 @@ topology_template:
       description: Directory where visualization data will be accesible on a cloud instance
       default: "visualization"
       required: false
-    mount_point:
+    visualization_mount_point:
       type: string
       description: Directory where visualization data will be mounted from Cloud staging area
       default: "/mnt/visualization"
+      required: false
+    visualization_ca_pem:
+      description: "PEM-encoded certificate authority content, will be generated if not provided"
+      type: string
+      required: false
+    visualization_ca_key:
+      description: "Certificate authority private key content, will be generated if not provided"
+      type: string
+      required: false
+    visualization_ca_passphrase:
+      description: "Certificate authority private key passphrase"
+      type: string
       required: false
     visualization_port:
       type: integer
@@ -166,7 +178,7 @@ topology_template:
       type: org.lexis.common.ddi.nodes.SSHFSMountStagingAreaDataset
       properties:
         token: { get_input: token }
-        mount_point_directory: { get_input: mount_point }
+        mount_point_directory: { get_input: visualization_mount_point }
       requirements:
         - ddi_access:
             type_requirement: ddi_access
@@ -200,7 +212,7 @@ topology_template:
     MoveVisualizationData:
       type: org.lexis.common.datatransfer.nodes.MoveFile
       properties:
-        source_file:  {concat: [get_input: mount_point, "/*/*" ] }
+        source_file:  {concat: [get_input: visualization_mount_point, "/*/*" ] }
         destination: {get_input: visualization_directory}
         as_user: "root"
       requirements:
@@ -218,6 +230,9 @@ topology_template:
       properties:
         port: { get_input: visualization_port }
         walltime_minutes: { get_input: visualization_walltime_minutes }
+        ca_pem: { get_input: visualization_ca_pem }
+        ca_key: { get_input: visualization_ca_key }
+        ca_passphrase: { get_input: visualization_ca_passphrase }
       requirements:
         - hostedOnComputeHost:
             type_requirement: host


### PR DESCRIPTION
Self-signed certificates are not accepted by Chrome.
Creating instead a certificate signed by a certificate authority.
The certificate authority can be passed in TOSCA component Xpra poperties, or a cerificate authority will be generated.

Closes #24 
